### PR TITLE
Save / SaveAs logic for the whole package

### DIFF
--- a/MOPE/AppSettings.Designer.cs
+++ b/MOPE/AppSettings.Designer.cs
@@ -46,5 +46,17 @@ namespace B4.Mope {
                 this["EditorReadOnlyMode"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool ConfirmOverwritePackage {
+            get {
+                return ((bool)(this["ConfirmOverwritePackage"]));
+            }
+            set {
+                this["ConfirmOverwritePackage"] = value;
+            }
+        }
     }
 }

--- a/MOPE/AppSettings.settings
+++ b/MOPE/AppSettings.settings
@@ -8,5 +8,8 @@
     <Setting Name="EditorReadOnlyMode" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="ConfirmOverwritePackage" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/MOPE/BooleanPropertyChangedEventArgs.cs
+++ b/MOPE/BooleanPropertyChangedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace B4.Mope
+{
+	public class BooleanPropertyChangedEventArgs : EventArgs
+	{
+		public bool OldValue { get; }
+		public bool NewValue { get; }
+
+		public BooleanPropertyChangedEventArgs(bool oldValue, bool newValue)
+		{
+			OldValue = oldValue;
+			NewValue = newValue;
+		}
+	}
+}

--- a/MOPE/Data.cs
+++ b/MOPE/Data.cs
@@ -50,9 +50,6 @@ namespace B4.Mope
 			get { return (bool)GetValue(EditorDarkModeProperty); }
 			set { SetValue(EditorDarkModeProperty, value); }
 		}
-
-		public bool IsPackageDirty { get; internal set; }
-
 		private static void EditorDarkPropertyChanged(DependencyObject obj, DependencyPropertyChangedEventArgs e)
 		{
 			var data = (Data)obj;
@@ -61,9 +58,27 @@ namespace B4.Mope
 			data.EditorDarkModeChanged?.Invoke(data, new BooleanPropertyChangedEventArgs((bool)e.OldValue, (bool)e.NewValue));
 		}
 
+
+		private static readonly DependencyProperty ConfirmOverwritePackageProperty = DependencyProperty.Register("ConfirmOverwritePackage", typeof(bool), typeof(Data), new PropertyMetadata(false, ConfirmOverwritePackagePropertyChanged));
+		public bool ConfirmOverwritePackage
+		{
+			get { return (bool)GetValue(ConfirmOverwritePackageProperty); }
+			set { SetValue(ConfirmOverwritePackageProperty, value); }
+		}
+		private static void ConfirmOverwritePackagePropertyChanged(DependencyObject obj, DependencyPropertyChangedEventArgs e)
+		{
+			var data = (Data)obj;
+			data.Settings.ConfirmOverwritePackage = (bool)e.NewValue;
+			data.Settings.Save();
+		}
+
+		public bool IsPackageDirty { get; internal set; }
+
 		public Data()
 		{
 			EditorReadOnlyMode = Settings.EditorReadOnlyMode;
+			EditorDarkMode = Settings.EditorUseDarkMode;
+			ConfirmOverwritePackage = Settings.ConfirmOverwritePackage;
 		}
 
 		public void OnReadOnlyModeChanged()
@@ -103,7 +118,7 @@ namespace B4.Mope
 			{
 				var shellCommands = LoadShellCommandsForPart(part);
 				var model = new PartModel(part, shellCommands);
-				PartModels.Add(part.Uri, model);
+				PartModels.Add(part.Uri.Replace('\\','/'), model);
 			}
 		}
 

--- a/MOPE/Data.cs
+++ b/MOPE/Data.cs
@@ -51,6 +51,8 @@ namespace B4.Mope
 			set { SetValue(EditorDarkModeProperty, value); }
 		}
 
+		public bool IsPackageDirty { get; internal set; }
+
 		private static void EditorDarkPropertyChanged(DependencyObject obj, DependencyPropertyChangedEventArgs e)
 		{
 			var data = (Data)obj;

--- a/MOPE/Data.cs
+++ b/MOPE/Data.cs
@@ -4,13 +4,14 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Windows;
 
 namespace B4.Mope
 {
 	/// <summary>
 	/// Data holder for app
 	/// </summary>
-	public class Data
+	public class Data : DependencyObject
 	{
 		public Package Package { get; private set; }
 
@@ -23,6 +24,50 @@ namespace B4.Mope
 		public IList<string> Applications { get; private set; } = new List<string>();
 		public List<PackageItem> Items { get; private set; }
 		internal AppSettings Settings { get; } = new AppSettings();
+
+		public delegate void BooleanPropertyChangedEventHandler(object sender, BooleanPropertyChangedEventArgs e);
+
+		public event BooleanPropertyChangedEventHandler EditorReadOnlyModeChanged;
+		private static readonly DependencyProperty EditorReadOnlyModeProperty = DependencyProperty.Register("EditorReadOnlyMode", typeof(bool), typeof(Data), new PropertyMetadata(false, EditorReadOnlyPropertyChanged));
+		public bool EditorReadOnlyMode
+		{
+			get { return (bool)GetValue(EditorReadOnlyModeProperty); }
+			set { SetValue(EditorReadOnlyModeProperty, value); }
+		}
+
+		private static void EditorReadOnlyPropertyChanged(DependencyObject obj, DependencyPropertyChangedEventArgs e)
+		{
+			var data = (Data)obj;
+			data.Settings.EditorReadOnlyMode = (bool)e.NewValue;
+			data.Settings.Save();
+			data.EditorReadOnlyModeChanged?.Invoke(data, new BooleanPropertyChangedEventArgs((bool)e.OldValue, (bool)e.NewValue));
+		}
+
+		public event BooleanPropertyChangedEventHandler EditorDarkModeChanged;
+		private static readonly DependencyProperty EditorDarkModeProperty = DependencyProperty.Register("EditorDarkMode", typeof(bool), typeof(Data), new PropertyMetadata(false, EditorDarkPropertyChanged));
+		public bool EditorDarkMode
+		{
+			get { return (bool)GetValue(EditorDarkModeProperty); }
+			set { SetValue(EditorDarkModeProperty, value); }
+		}
+
+		private static void EditorDarkPropertyChanged(DependencyObject obj, DependencyPropertyChangedEventArgs e)
+		{
+			var data = (Data)obj;
+			data.Settings.EditorUseDarkMode = (bool)e.NewValue;
+			data.Settings.Save();
+			data.EditorDarkModeChanged?.Invoke(data, new BooleanPropertyChangedEventArgs((bool)e.OldValue, (bool)e.NewValue));
+		}
+
+		public Data()
+		{
+			EditorReadOnlyMode = Settings.EditorReadOnlyMode;
+		}
+
+		public void OnReadOnlyModeChanged()
+		{
+
+		}
 
 		public void Reset()
 		{

--- a/MOPE/MainWindow.xaml
+++ b/MOPE/MainWindow.xaml
@@ -9,7 +9,6 @@
 		mc:Ignorable="d"
 		Title="MOPE: Office Package Editor" Height="720" Width="1200">
 	<Window.Resources>
-		<local:Data x:Key="appData" />
 		<localUI:PartModelToBitmapSourceConverter x:Key="partModelToBitmapSourceConverter" />
 		<localUI:PackageItemToBitmapSourceConverter x:Key="packageItemToBitmapSourceConverter" />
 		<localUI:PartModelToSizeStringConverter x:Key="partModelToSizeStringConverter" />
@@ -56,6 +55,7 @@
 		</ContextMenu>
 
 		<MenuItem x:Key="debugMenu" Header="Debug" HorizontalAlignment="Right" HorizontalContentAlignment="Right">
+			<MenuItem Header="Break" Click="debugBreak_Click" />
 			<MenuItem Header="Inject JS code" Click="debugInjectJsMenuItem_Click" />
 		</MenuItem>
 
@@ -76,8 +76,8 @@
 			</MenuItem>
 			<MenuItem Header="_View" x:Name="toolbarViewMenu">
 				<MenuItem Header="Code Editor">
-					<MenuItem Header="Dark Mode" x:Name="editorDarkModeMenuItem" IsCheckable="True" Checked="editorDarkModeMenuItem_Change" Unchecked="editorDarkModeMenuItem_Change"/>
-					<MenuItem Header="Read Only" x:Name="editorReadOnlyModeMenuItem" IsCheckable="True" Checked="editorReadOnlyModeMenuItem_Change" Unchecked="editorReadOnlyModeMenuItem_Change"/>
+					<MenuItem Header="Dark Mode" x:Name="editorDarkModeMenuItem" IsCheckable="True" IsChecked="{Binding EditorDarkMode, Mode=TwoWay}"/>
+					<MenuItem Header="Read Only" x:Name="editorReadOnlyModeMenuItem" IsCheckable="True" IsChecked="{Binding EditorReadOnlyMode, Mode=TwoWay}"/>
 				</MenuItem>
 				<Separator />
 				<localUI:ListViewStateMenuItem Header="Tiles" ViewState="Tiles" Click="ListViewStateMenuItem_Click"/>

--- a/MOPE/MainWindow.xaml
+++ b/MOPE/MainWindow.xaml
@@ -66,17 +66,21 @@
 		<CommandBinding Command="Save" CanExecute="CommandBinding_SaveCanExecute" Executed="CommandBinding_SaveExecuted"/>
 		<CommandBinding Command="localUI:CustomCommands.SaveAs" CanExecute="CommandBinding_SaveAsCanExecute" Executed="CommandBinding_SaveAsExecuted"/>
 		<CommandBinding Command="localUI:CustomCommands.SavePackage" CanExecute="CommandBinding_SavePackageCanExecute" Executed="CommandBinding_SavePackageExecuted"/>
+		<CommandBinding Command="localUI:CustomCommands.SavePackageAs" CanExecute="CommandBinding_SavePackageAsCanExecute" Executed="CommandBinding_SavePackageAsExecuted"/>
 	</Window.CommandBindings>
 	<DockPanel>
 		<Menu IsMainMenu="True" x:Name="menuMain" DockPanel.Dock="Top">
 			<MenuItem Header="_File">
 				<MenuItem Header="_Open" Icon="📂" InputGestureText="Ctrl+O" Command="ApplicationCommands.Open"/>
 				<MenuItem Header="_Save Part" Icon="💾" InputGestureText="Ctrl+S" Command="ApplicationCommands.Save"/>
-				<MenuItem Header="Save Part _As" Command="ApplicationCommands.SaveAs"/>
+				<MenuItem Header="Save Part _As" Command="localUI:CustomCommands.SaveAs"/>
 				<Separator />
-				<MenuItem Header="_Save Package" Icon="💾" InputGestureText="Ctrl+Shift+S" />
+				<MenuItem Header="Save _Package" Icon="💾" InputGestureText="Ctrl+Shift+S" Command="localUI:CustomCommands.SavePackage" />
+				<MenuItem Header="Save Package As" Icon="💾" InputGestureText="Ctrl+Shift+F12" Command="localUI:CustomCommands.SavePackageAs" />
 				<Separator />
 				<MenuItem Header="E_xit" Click="Exit_Click" />
+				<Separator />
+				<MenuItem Header="Confirm Overwrite Package" IsCheckable="True" IsChecked="{Binding ConfirmOverwritePackage, Mode=TwoWay}"/>
 			</MenuItem>
 			<MenuItem Header="_View" x:Name="toolbarViewMenu">
 				<MenuItem Header="Code Editor">

--- a/MOPE/MainWindow.xaml
+++ b/MOPE/MainWindow.xaml
@@ -64,13 +64,17 @@
 		<!--<CommandBinding Command="Help" CanExecute="CommandBinding_HelpCanExecute" Executed="CommandBinding_HelpExecuted"/>-->
 		<CommandBinding Command="Open" CanExecute="CommandBinding_OpenCanExecute" Executed="CommandBinding_OpenExecuted"/>
 		<CommandBinding Command="Save" CanExecute="CommandBinding_SaveCanExecute" Executed="CommandBinding_SaveExecuted"/>
+		<CommandBinding Command="localUI:CustomCommands.SaveAs" CanExecute="CommandBinding_SaveAsCanExecute" Executed="CommandBinding_SaveAsExecuted"/>
+		<CommandBinding Command="localUI:CustomCommands.SavePackage" CanExecute="CommandBinding_SavePackageCanExecute" Executed="CommandBinding_SavePackageExecuted"/>
 	</Window.CommandBindings>
 	<DockPanel>
 		<Menu IsMainMenu="True" x:Name="menuMain" DockPanel.Dock="Top">
 			<MenuItem Header="_File">
 				<MenuItem Header="_Open" Icon="📂" InputGestureText="Ctrl+O" Command="ApplicationCommands.Open"/>
-				<MenuItem Header="_Save" Icon="💾" InputGestureText="Ctrl+S" Command="ApplicationCommands.Save"/>
-				<MenuItem Header="Save _As" Command="ApplicationCommands.SaveAs"/>
+				<MenuItem Header="_Save Part" Icon="💾" InputGestureText="Ctrl+S" Command="ApplicationCommands.Save"/>
+				<MenuItem Header="Save Part _As" Command="ApplicationCommands.SaveAs"/>
+				<Separator />
+				<MenuItem Header="_Save Package" Icon="💾" InputGestureText="Ctrl+Shift+S" />
 				<Separator />
 				<MenuItem Header="E_xit" Click="Exit_Click" />
 			</MenuItem>

--- a/MOPE/MainWindow.xaml.cs
+++ b/MOPE/MainWindow.xaml.cs
@@ -96,11 +96,20 @@ namespace B4.Mope
 
 		private void CommandBinding_SaveAsCanExecute(object sender, CanExecuteRoutedEventArgs e)
 		{
-			// TODO: Check for open file
-			e.CanExecute = true;
+			e.CanExecute = (Data.Package != null) && (partsTabControl.SelectedItem != null);
 		}
 
 		private void CommandBinding_SaveAsExecuted(object sender, ExecutedRoutedEventArgs e)
+		{
+
+		}
+
+		private void CommandBinding_SavePackageCanExecute(object sender, CanExecuteRoutedEventArgs e)
+		{
+			e.CanExecute = (Data.Package != null) && Data.IsPackageDirty;
+		}
+
+		private void CommandBinding_SavePackageExecuted(object sender, ExecutedRoutedEventArgs e)
 		{
 
 		}

--- a/MOPE/Packaging/Package.cs
+++ b/MOPE/Packaging/Package.cs
@@ -37,7 +37,7 @@ namespace B4.Mope.Packaging
 			foreach (var entry in entries)
 			{
 				var part = new Part(this, entry.Name, entry.FullName, ContentTypes.GetContentType(entry.FullName), entry.Crc32, entry.Length, entry.CompressedLength);
-				Parts.Add(part.Uri, part);
+				Parts.Add(part.Uri.Replace('\\','/'), part);
 			}
 
 			Relationships = LoadRelationships();
@@ -81,7 +81,7 @@ namespace B4.Mope.Packaging
 			foreach (var part in Parts.Values.Where(p => p.Name.EndsWith(".rels")))
 			{
 				Relationships rels;
-				string source = Relationships.GetRelationshipPartOwner(part.Uri);
+				string source = Relationships.GetRelationshipPartOwner(part.Uri.Replace('\\', '/'));
 				using (var stream = part.GetFileInfo().OpenRead())
 				{
 					rels = Relationships.Load(this, source, stream);

--- a/MOPE/UI/BinaryViewTabItem.xaml
+++ b/MOPE/UI/BinaryViewTabItem.xaml
@@ -13,6 +13,6 @@
 		<local:CloseButtonTabHeader Text="Test1⚡🧩🎨🎵🖥✖❌  " />
 	</TabItem.Header>
 	<DockPanel LastChildFill="True">
-		<hex:HexEditor x:Name="Editor"/>
+		<hex:HexEditor x:Name="Editor" ReadOnlyMode="{Binding Path=EditorReadOnlyMode}" />
 	</DockPanel>
 </TabItem>

--- a/MOPE/UI/BinaryViewTabItem.xaml.cs
+++ b/MOPE/UI/BinaryViewTabItem.xaml.cs
@@ -21,37 +21,23 @@ namespace B4.Mope.UI
 	/// </summary>
 	public partial class BinaryViewTabItem : TabItem
 	{
-		public BinaryViewTabItem()
+		public BinaryViewTabItem(Data data, PartModel partModel)
 		{
 			InitializeComponent();
+			Data = data ?? throw new ArgumentNullException(nameof(data));
+			PartModel = partModel ?? throw new ArgumentNullException(nameof(partModel));
+			UpdatePartView();
 		}
 
-		private Part m_part;
-		public Part Part
+		private void UpdatePartView()
 		{
-			get { return m_part; }
-			set
-			{
-				m_part = value;
-				if (m_part != null)
-				{
-					var data = (Data)Window.GetWindow(this).DataContext;
-					var header = ((CloseButtonTabHeader)Header);
-					header.Text = $"{m_part.Uri}";
-					header.ViewType = "🧩";
-					Editor.FileName = m_part.GetFileInfo().FullName;
-				}
-				else
-				{
-					((CloseButtonTabHeader)Header).Text = "???";
-					Content = new TextBlock()
-					{
-						Text = "Error: null part"
-					};
-				}
-			}
+			var header = ((CloseButtonTabHeader)Header);
+			header.Text = $"{PartModel.Part.Uri}";
+			header.ViewType = "🧩";
+			Editor.FileName = PartModel.Part.GetFileInfo().FullName;
 		}
 
-
+		public Data Data { get; }
+		public PartModel PartModel { get; }
 	}
 }

--- a/MOPE/UI/ConfirmOverwritePackageDialog.xaml
+++ b/MOPE/UI/ConfirmOverwritePackageDialog.xaml
@@ -1,0 +1,23 @@
+﻿<Window x:Class="B4.Mope.UI.ConfirmOverwritePackageDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:B4.Mope.UI"
+        mc:Ignorable="d"
+        Title="ConfirmOverwritePackageDialog" Height="114" Width="399"
+		Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}">
+	<StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+		<Label>Are you sure you want to overwrite the existing package?</Label>
+		<CheckBox x:Name="dontShowThisCheckbox">
+			<CheckBox.LayoutTransform>
+				<ScaleTransform ScaleX="0.75" ScaleY="0.75"/>
+			</CheckBox.LayoutTransform>
+			D_on't show this dialog again
+		</CheckBox>
+		<StackPanel Orientation="Horizontal" Margin="10">
+			<Button x:Name="buttonYes" Margin="0,0,10,0" Click="buttonYes_Click">_Yes</Button>
+			<Button x:Name="buttonNo" Click="buttonNo_Click">_No</Button>
+		</StackPanel>
+	</StackPanel>
+</Window>

--- a/MOPE/UI/ConfirmOverwritePackageDialog.xaml.cs
+++ b/MOPE/UI/ConfirmOverwritePackageDialog.xaml.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace B4.Mope.UI
+{
+	/// <summary>
+	/// Interaction logic for ConfirmOverwritePackageDialog.xaml
+	/// </summary>
+	public partial class ConfirmOverwritePackageDialog : Window
+	{
+		public MessageBoxResult Result { get; private set; }
+		public bool DontShowDialogAgain
+		{
+			get { return dontShowThisCheckbox.IsChecked == true; }
+		}
+
+		public ConfirmOverwritePackageDialog()
+		{
+			InitializeComponent();
+		}
+
+		private void buttonYes_Click(object sender, RoutedEventArgs e)
+		{
+			Result = MessageBoxResult.Yes;
+			Close();
+		}
+
+		private void buttonNo_Click(object sender, RoutedEventArgs e)
+		{
+			Result = MessageBoxResult.No;
+			Close();
+		}
+	}
+}

--- a/MOPE/UI/CustomCommands.cs
+++ b/MOPE/UI/CustomCommands.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows.Input;
+
+namespace B4.Mope.UI
+{
+	public static class CustomCommands
+	{
+		public static readonly RoutedUICommand SaveAs = new RoutedUICommand(
+			"Save As",
+			"SaveAs",
+			typeof(CustomCommands));
+
+		public static readonly RoutedUICommand SavePackage = new RoutedUICommand(
+			"Save Package",
+			"SavePackage",
+			typeof(CustomCommands),
+			new InputGestureCollection() { new KeyGesture(Key.S, ModifierKeys.Control | ModifierKeys.Shift) });
+	}
+}

--- a/MOPE/UI/CustomCommands.cs
+++ b/MOPE/UI/CustomCommands.cs
@@ -10,12 +10,19 @@ namespace B4.Mope.UI
 		public static readonly RoutedUICommand SaveAs = new RoutedUICommand(
 			"Save As",
 			"SaveAs",
-			typeof(CustomCommands));
+			typeof(CustomCommands),
+			new InputGestureCollection() { new KeyGesture(Key.F12) });
 
 		public static readonly RoutedUICommand SavePackage = new RoutedUICommand(
 			"Save Package",
 			"SavePackage",
 			typeof(CustomCommands),
 			new InputGestureCollection() { new KeyGesture(Key.S, ModifierKeys.Control | ModifierKeys.Shift) });
+
+		public static readonly RoutedUICommand SavePackageAs = new RoutedUICommand(
+			"Save Package As",
+			"SavePackageAs",
+			typeof(CustomCommands),
+			new InputGestureCollection() { new KeyGesture(Key.F12, ModifierKeys.Control | ModifierKeys.Shift) });
 	}
 }

--- a/MOPE/WebHost.cs
+++ b/MOPE/WebHost.cs
@@ -130,6 +130,8 @@ namespace B4.Mope
 			partModel.SetDirty(true);
 			context.Response.StatusCode = 200;
 			context.Response.OutputStream.Close();
+
+			Data.IsPackageDirty = true;
 		}
 
 		private static void ListenerCallback(IAsyncResult result)

--- a/MOPE/WebHost.cs
+++ b/MOPE/WebHost.cs
@@ -168,6 +168,7 @@ namespace B4.Mope
 			//	}
 			//}
 
+			Data.IsPackageDirty = true;
 			partModel.SetDirty(false);
 			context.Response.StatusCode = 200;
 			context.Response.OutputStream.Close();


### PR DESCRIPTION
Plus some other small changes:
- Settings are now data bound with their UI entry points
- BinaryViewTabItem uses PartModel
- Read-only support for hex editor