### PR TITLE
Fix archive save/saveas

### DIFF
--- a/MOPE/Data.cs
+++ b/MOPE/Data.cs
@@ -224,6 +224,15 @@ namespace B4.Mope
 			}
 		}
 
+		public void SaveAs(string filename)
+		{
+			PackageWatcher.EnableRaisingEvents = false;
+
+			Package.SaveAs(filename);
+
+			PackageWatcher.EnableRaisingEvents = true;
+		}
+
 		// // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
 		// ~Data()
 		// {

--- a/MOPE/MainWindow.xaml.cs
+++ b/MOPE/MainWindow.xaml.cs
@@ -200,33 +200,19 @@ namespace B4.Mope
 			}
 		}
 
-		private Stream CreateZipArchiveStream()
-		{
-			var stream = new MemoryStream();
-			using (var zipArchive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
-			{
-				foreach (var part in Data.Package.Parts.Values)
-				{
-					zipArchive.CreateEntryFromFile(part.GetFileInfo().FullName, part.Uri.Replace('/', '\\'));
-				}
-			}
-
-			stream.Seek(0, SeekOrigin.Begin);
-			return stream;
-		}
-
 		private void SavePackageAs(string filename)
 		{
 			SaveDirtyParts();
 
-			Data.PackageWatcher.EnableRaisingEvents = false;
-			// create the archive and overwrite the file
-			using (var zipStream = CreateZipArchiveStream())
-			using (var file = new FileStream(filename, FileMode.OpenOrCreate, FileAccess.ReadWrite))
+			try
 			{
-				zipStream.CopyTo(file);
+				Data.SaveAs(filename);
+				Title = $"MOPE: {Data.Package.ZipFile}";
 			}
-			Data.PackageWatcher.EnableRaisingEvents = true;
+			catch (Exception exc)
+			{
+				MessageBox.Show(this, $"Error saving to {filename}\r\n\r\n{exc}", "File Error", MessageBoxButton.OK, MessageBoxImage.Error);
+			}
 		}
 
 		private void CommandBinding_SavePackageAsCanExecute(object sender, CanExecuteRoutedEventArgs e)

--- a/MOPE/Packaging/Package.cs
+++ b/MOPE/Packaging/Package.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 
 namespace B4.Mope.Packaging
 {
 	public class Package : IDisposable
 	{
-		public string ZipFile { get; }
+		public string ZipFile { get; private set; }
 		public string TempDirectory { get; }
 		public Dictionary<string, Part> Parts { get; } = new Dictionary<string, Part>();
 		public ContentTypes ContentTypes { get; }
@@ -27,7 +28,6 @@ namespace B4.Mope.Packaging
 				Directory.Delete(TempDirectory, true);
 
 			var tempDir = Directory.CreateDirectory(TempDirectory);
-
 			var entries = ZipContainer.ExtractTo(ZipFile, TempDirectory, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
 
 			// read [Content_Types].xml
@@ -147,6 +147,16 @@ namespace B4.Mope.Packaging
 			// TODO: uncomment the following line if the finalizer is overridden above.
 			// GC.SuppressFinalize(this);
 		}
+
 		#endregion
+
+		public void SaveAs(string filename)
+		{
+			if (File.Exists(filename))
+				File.Delete(filename);
+
+			System.IO.Compression.ZipFile.CreateFromDirectory(TempDirectory, filename);
+			ZipFile = filename;
+		}
 	}
 }


### PR DESCRIPTION
Zip file save / save as is broken. Enumerating and creating individual ZipEntry results in a local file header corruption.

Switch to ZipFile.CreateFromDirectory.